### PR TITLE
Clarify RRsets with no issue/issuewild.

### DIFF
--- a/draft-ietf-lamps-rfc6844bis.md
+++ b/draft-ietf-lamps-rfc6844bis.md
@@ -480,6 +480,11 @@ CAA authorizations are additive; thus, the result of specifying both
 the empty issuer and a specified issuer is the same as specifying
 just the specified issuer alone.
 
+A non-empty CAA record set that contains no issue or issuewild property tags
+is authorization to any certificate issuer to issue for the corresponding
+domain, provided that no records in the CAA record set otherwise prohibit
+issuance.
+
 An issuer MAY choose to specify issuer-parameters that further
 constrain the issue of certificates by that issuer, for example,
 specifying that certificates are to be subject to specific validation

--- a/draft-ietf-lamps-rfc6844bis.md
+++ b/draft-ietf-lamps-rfc6844bis.md
@@ -480,10 +480,10 @@ CAA authorizations are additive; thus, the result of specifying both
 the empty issuer and a specified issuer is the same as specifying
 just the specified issuer alone.
 
-A non-empty CAA record set that contains no issue or issuewild property tags
+A non-empty CAA record set that contains no issue property tags
 is authorization to any certificate issuer to issue for the corresponding
-domain, provided that no records in the CAA record set otherwise prohibit
-issuance.
+domain, provided that it is a non-wildcard domain, and no records in the
+CAA record set otherwise prohibit issuance.
 
 An issuer MAY choose to specify issuer-parameters that further
 constrain the issue of certificates by that issuer, for example,
@@ -508,6 +508,11 @@ a domain that is not a wildcard domain.
 If at least one issuewild property is specified in the relevant
 CAA record set, all issue properties MUST be ignored when
 processing a request for a domain that is a wildcard domain.
+
+A non-empty CAA record set that contains no issue or issuewild property tags
+is authorization to any certificate issuer to issue for the corresponding
+wildcard domain, provided that no records in the CAA record set otherwise
+prohibit issuance.
 
 ##  CAA iodef Property
 

--- a/draft-ietf-lamps-rfc6844bis.md
+++ b/draft-ietf-lamps-rfc6844bis.md
@@ -438,18 +438,15 @@ authorization to specific certificate issuers.
 The CAA issue property value has the following sub-syntax (specified
 in ABNF as per {{!RFC5234}}).
 
-issuevalue  = space \[domain] space \[";" *(space parameter) space]
+issuevalue = *WSP [domain] *WSP [";" *WSP [parameters] *WSP]
 
 domain = label *("." label)
 label = (ALPHA / DIGIT) *( *("-") (ALPHA / DIGIT))
 
-space = *(SP / HTAB)
-
-parameter =  tag "=" value
-
-tag = 1*(ALPHA / DIGIT)
-
-value = *VCHAR
+parameters = (parameter *WSP “;” *WSP parameters) / parameter
+parameter = tag *WSP "=" *WSP value
+tag = (ALPHA / DIGIT) *( *("-") (ALPHA / DIGIT))
+value = *(%x21-3A / %x3C-7E)
 
 For consistency with other aspects of DNS administration, domain name
 values are specified in letter-digit-hyphen Label (LDH-Label) form.


### PR DESCRIPTION
As proposed in [erratum 5244](https://www.rfc-editor.org/errata/eid5244), clarify that non-empty CAA RR sets with no issue or issuewild property tags are permission to issue.

See also [mailing list thread](https://www.ietf.org/mail-archive/web/spasm/current/msg01104.html).