### PR TITLE
Tree climbing stops after a CAA RRset is found

### DIFF
--- a/draft-ietf-lamps-rfc6844bis.md
+++ b/draft-ietf-lamps-rfc6844bis.md
@@ -280,7 +280,7 @@ the domains and wildcard domains specified in the request.
 
 The search for a CAA record climbs the DNS name tree from the
 specified label up to but not including the DNS root '.'
-until CAA records are found.
+until a CAA Resource Record set is found.
 
 Given a request for a specific domain name X, or a request for a wildcard domain
 name *.X, the relevant record set RelevantCAASet(X) is determined as follows:


### PR DESCRIPTION
(not after 'CAA records' are found).