### PR TITLE
Capitalize all Defined Terms

### DIFF
--- a/draft-ietf-lamps-rfc6844bis.md
+++ b/draft-ietf-lamps-rfc6844bis.md
@@ -585,7 +585,7 @@ unknown Resource Record types is NOERROR.
 ## Delegation to Private Nameservers
 
 Some Domain Name administrators make the contents of a subdomain unresolvable on the
-public internet by delegating that subdomain to a nameserver whose IP address is
+public Internet by delegating that subdomain to a nameserver whose IP address is
 private. A CA processing CAA records for such subdomains will receive
 SERVFAIL from its recursive resolver. The CA MAY interpret that as preventing
 issuance. Domain Name administrators wishing to issue certificates for private


### PR DESCRIPTION
In the process I realized "domain name" and "Domain Name" were used, but not defined, so I added a definition (copied from BRs).

I also changed most instances of "resource record set" to "RRSet".

Also, changed "a domain name that is not a wildcard domain name" to "a Domain Name (that is, not a Wildcard Domain Name)" since Wildcard Domain Names are definitionally not Domain Names.